### PR TITLE
Make toString() method generate New-Line compatible JSON, ie non-beautified

### DIFF
--- a/src/main/scala/com/vpalos/Json.scala
+++ b/src/main/scala/com/vpalos/Json.scala
@@ -16,7 +16,7 @@ import scala.util.parsing.combinator.{PackratParsers, RegexParsers}
  * or low memory usage, it is meant to be useful in scripting scenarios where navigating the
  * JSON structure can be rather verbose.
  */
-abstract class Json extends Dynamic {
+abstract class Json extends Dynamic with Serializable {
 
   /**
    * Dynamic look-ups.

--- a/src/test/scala/com/vpalos/JsonTest.scala
+++ b/src/test/scala/com/vpalos/JsonTest.scala
@@ -325,32 +325,37 @@ class JsonTest extends FlatSpec with Matchers {
   /**
    * Rendering tests.
    */
-  val json = Json.parse("""{"a":123,"b":{"c":4.56, "d":[1,2,{"e":"f"},4]},"g":7}""")
-  assert(json.toString ==
-    """{
-      |  "a": 123,
-      |  "b": {
-      |    "c": 4.56,
-      |    "d": [
-      |      1,
-      |      2,
-      |      {
-      |        "e": "f"
-      |      },
-      |      4
-      |    ]
-      |  },
-      |  "g": 7
-      |}""".stripMargin)
-  assert(json.b.d.toString ==
-    """[
-      |  1,
-      |  2,
-      |  {
-      |    "e": "f"
-      |  },
-      |  4
-      |]""".stripMargin)
+  it should "properly serialize beautified and non-beautified JSONs" in {
+    val json = Json.parse("""{"a":123,"b":{"c":4.56, "d":[1,2,{"e":"f"},4]},"g":7}""")
+    assert(json.toString == """{"a":123,"b":{"c":4.56,"d":[1,2,{"e":"f"},4]},"g":7}""")
+    assert(json.toString("") ==
+      """{
+        |  "a": 123,
+        |  "b": {
+        |    "c": 4.56,
+        |    "d": [
+        |      1,
+        |      2,
+        |      {
+        |        "e": "f"
+        |      },
+        |      4
+        |    ]
+        |  },
+        |  "g": 7
+        |}""".stripMargin.replace("\r",""))
+    assert(json.b.d.toString == """[1,2,{"e":"f"},4]""" )
+    assert(json.b.d.toString("") ==
+      """[
+        |  1,
+        |  2,
+        |  {
+        |    "e": "f"
+        |  },
+        |  4
+        |]""".stripMargin.replace("\r",""))
+    }
+
 
   /**
    * Object creation tests.


### PR DESCRIPTION
@vpalos  The beautified JSON is generated by calling toString(prefix: String)
Why: the are a lot of usages of JsonLines (jsonlines.org) format, like when bulk inserting data into from Apache Spark into an ElasticSearch cluster, and this library doesn't offer such functionality.
Thanks